### PR TITLE
Set up schemas / type interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,16 @@ To use Mapbox tiles instead of the default (OpenStreetMap), you'll need to creat
 Add the following variable to your `.env`:
 
 ```
-MAPBOX_TOKEN=<your token>
+GATSBY_MAPBOX_TOKEN=<your token>
 ```
+
+The `GATSBY_` prefix is required to use environment variables in client-side code.
 
 ### Custom style
 
 If you want to use a [Mapbox style](https://docs.mapbox.com/studio-manual/reference/styles/) you created in Mapbox Studio, then also add: 
 
 ```
-MAPBOX_USERNAME=<your username>
-MAPBOX_STYLE=<your style id>
+GATSBY_MAPBOX_USERNAME=<your username>
+GATSBY_MAPBOX_STYLE=<your style id>
 ```

--- a/src/components/Map.types.ts
+++ b/src/components/Map.types.ts
@@ -1,25 +1,26 @@
 export interface Node {
   // This could be a MAC address, an installation ID we use internally, or a UUID generated just for this code
-  id: string|number,
+  nodeId: string|number,
+  // The internal type of this node: only "mesh" or "hub" for now.
+  nodeType: string,
   // User-facing label
   label?: string,
   // Lat/long
   lat: number,
   long: number,
-  // Direction the antenna is facing. How do we calculate these during install 
-  // and record it in a standard way? What do maps people use for angles
+  // Direction the antenna is facing, expressed as a compass heading with 0/360=North, 90=East, etc.
   direction: number,
-  // Information about device installed here
+  // Information about device installed at this node
   device: Device,
-  // Other nodes that are meshed with this one, either a relation or ID
+  // Other nodes that are meshed with this one, either by a relation or passed nodeId
   meshedWith: Node[]|(string[]|number[]),
 }
 
 export interface Device {
   // Name of the device
   name: string,
-  // Signal range (angle)
-  angleRange: number,
-  // Signal range (distance)
-  distanceRange: number,
+  // Signal range - angle of coverage
+  signalRangeAngle: number,
+  // Signal range - distance out from the antenna
+  signalRangeDistance: number,
 }

--- a/src/components/Map.types.ts
+++ b/src/components/Map.types.ts
@@ -1,0 +1,25 @@
+export interface Node {
+  // This could be a MAC address, an installation ID we use internally, or a UUID generated just for this code
+  id: string|number,
+  // User-facing label
+  label?: string,
+  // Lat/long
+  lat: number,
+  long: number,
+  // Direction the antenna is facing. How do we calculate these during install 
+  // and record it in a standard way? What do maps people use for angles
+  direction: number,
+  // Information about device installed here
+  device: Device,
+  // Other nodes that are meshed with this one, either a relation or ID
+  meshedWith: Node[]|(string[]|number[]),
+}
+
+export interface Device {
+  // Name of the device
+  name: string,
+  // Signal range (angle)
+  angleRange: number,
+  // Signal range (distance)
+  distanceRange: number,
+}

--- a/src/components/Map.types.ts
+++ b/src/components/Map.types.ts
@@ -13,6 +13,7 @@ export interface Node {
   // Information about device installed at this node
   device: Device,
   // Other nodes that are meshed with this one, either by a relation or passed nodeId
+  // Might be a single `uplink` node if we only have data on a single uplink device
   meshedWith: Node[]|(string[]|number[]),
 }
 


### PR DESCRIPTION
Addressing #5

a5bb77cfd17313613e18e9edb0f778fa223427d5: Took my first pass at a schema for our `Node` data. I separated `Device` into its own interface since we'll probably be re-using the same `Device` for many `Node`s. Would love feedback & I have some open questions, for instance:

* What is the best way to record and store facing angle / rotation information for these antennas? How do people usually do this in a geolocation context?
* Should we store meshed nodes as a property on each node, or use a separate graph for this?
* Better prop names than `angleRange` and `distanceRange`? 
* Anything I missed / anything unnecessary?