### PR TITLE
Set up daily Netlify build GH action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: Periodic Netlify build trigger
+
+on:
+  schedule:
+    # Run at 5:50 AM UTC every day
+    - cron: "50 5 * * *"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl request to Netlify's build hook
+        env:
+          BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
+        run: |
+          curl -X POST -d {} "$BUILD_HOOK"


### PR DESCRIPTION
Add a GitHub Action to regularly build the site by sending a `POST` request to our Netlify [build hook](https://docs.netlify.com/configure-builds/build-hooks/). Relies on the `NETLIFY_BUILD_HOOK` [encrypted secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) (in the GH settings for this repo).